### PR TITLE
ppc64le: Add ppc64le support to nvidia-container-runtime.

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -30,7 +30,8 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 
 ENV GOLANG_VERSION 1.8.3
-RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+ARG GO_ARCH
+RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz \
     | tar -v -C /usr/local -xz
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.8.3
-RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+ARG GO_ARCH
+
+RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz \
     | tar -v -C /usr/local -xz
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,19 @@ xenial: 17.09.0-xenial 17.06.2-xenial 17.06.1-xenial 17.03.2-xenial 1.13.1-xenia
 
 centos7: 17.09.0-centos7 17.06.2-centos7 17.06.1-centos7 17.03.2-centos7 1.12.6-centos7
 
+ifeq ($(shell uname -p),ppc64le)
+ARCH    ?= ppc64le
+PKG_ARCH ?= ppc64le
+else
+ARCH    ?= amd64
+PKG_ARCH ?= x86_64
+endif
+
 17.09.0-xenial:
 	$(DOCKER) build --build-arg RUNC_COMMIT="3f2f8b84a77f73d38244dd690525642a72156c64" \
                         --build-arg PKG_VERS="$(VERSION)+docker17.09.0" \
                         --build-arg PKG_REV="$(PKG_REV)" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.xenial .
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
@@ -27,6 +36,7 @@ centos7: 17.09.0-centos7 17.06.2-centos7 17.06.1-centos7 17.03.2-centos7 1.12.6-
 	$(DOCKER) build --build-arg RUNC_COMMIT="810190ceaa507aa2727d7ae6f4790c76ec150bd2" \
                         --build-arg PKG_VERS="$(VERSION)+docker17.06.2" \
                         --build-arg PKG_REV="$(PKG_REV)" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.xenial .
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
@@ -34,6 +44,7 @@ centos7: 17.09.0-centos7 17.06.2-centos7 17.06.1-centos7 17.03.2-centos7 1.12.6-
 	$(DOCKER) build --build-arg RUNC_COMMIT="810190ceaa507aa2727d7ae6f4790c76ec150bd2" \
                         --build-arg PKG_VERS="$(VERSION)+docker17.06.1" \
                         --build-arg PKG_REV="$(PKG_REV)" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.xenial .
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
@@ -41,6 +52,7 @@ centos7: 17.09.0-centos7 17.06.2-centos7 17.06.1-centos7 17.03.2-centos7 1.12.6-
 	$(DOCKER) build --build-arg RUNC_COMMIT="54296cf40ad8143b62dbcaa1d90e520a2136ddfe" \
                         --build-arg PKG_VERS="$(VERSION)+docker17.03.2" \
                         --build-arg PKG_REV="$(PKG_REV)" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.xenial .
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
@@ -48,6 +60,7 @@ centos7: 17.09.0-centos7 17.06.2-centos7 17.06.1-centos7 17.03.2-centos7 1.12.6-
 	$(DOCKER) build --build-arg RUNC_COMMIT="9df8b306d01f59d3a8029be411de015b7304dd8f" \
                         --build-arg PKG_VERS="$(VERSION)+docker1.13.1" \
                         --build-arg PKG_REV="$(PKG_REV)" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.xenial .
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
@@ -55,45 +68,51 @@ centos7: 17.09.0-centos7 17.06.2-centos7 17.06.1-centos7 17.03.2-centos7 1.12.6-
 	$(DOCKER) build --build-arg RUNC_COMMIT="50a19c6ff828c58e5dab13830bd3dacde268afe5" \
                         --build-arg PKG_VERS="$(VERSION)+docker1.12.6" \
                         --build-arg PKG_REV="$(PKG_REV)" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.xenial .
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
 17.09.0-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="3f2f8b84a77f73d38244dd690525642a72156c64" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.09.0" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.centos7 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.06.2-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="810190ceaa507aa2727d7ae6f4790c76ec150bd2" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.06.2" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.centos7 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.06.1-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="810190ceaa507aa2727d7ae6f4790c76ec150bd2" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.06.1" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.centos7 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.03.2-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="54296cf40ad8143b62dbcaa1d90e520a2136ddfe" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.03.2" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.centos7 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 1.12.6-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="50a19c6ff828c58e5dab13830bd3dacde268afe5" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker1.12.6" \
+                        --build-arg GO_ARCH="$(ARCH)" \
                         -t nvidia-container-runtime:$@ -f Dockerfile.centos7 .
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@


### PR DESCRIPTION
In centos7 and xenial Dockerfiles the go package was defaulting to the
amd64 version.  Makefile, and the two respective Dockerfiles have been
updated to make the determination about which go library to install
based on the uname -p value on the current running machine.

This needs a little more work on the centos/rhel side.  rhel doesn't carry the libseccomp-devel nor the bmake packages natively.