### PR TITLE
Add support for Trusty

### DIFF
--- a/Dockerfile.trusty
+++ b/Dockerfile.trusty
@@ -1,0 +1,75 @@
+FROM ubuntu:trusty
+
+# runc dependencies
+RUN apt-get update && apt-get install -y \
+        wget \
+        git \
+        make \
+        pkg-config \
+        gcc \
+        libseccomp2=2.2.3-2ubuntu1~ubuntu14.04.1 \
+        libseccomp-dev=2.2.3-2ubuntu1~ubuntu14.04.1 \
+        libapparmor-dev \
+        libselinux1-dev \
+        build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.9.2
+RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+    | tar -v -C /usr/local -xz
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN go get github.com/LK4D4/vndr
+
+# packaging dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        dh-make \
+        fakeroot \
+        devscripts && \
+    rm -rf /var/lib/apt/lists/*
+
+# packaging
+ARG PKG_VERS
+ARG PKG_REV
+ARG PKG_ARCH
+
+ENV DEBFULLNAME "NVIDIA CORPORATION"
+ENV DEBEMAIL "cudatools@nvidia.com"
+ENV REVISION "$PKG_VERS-$PKG_REV"
+ENV DISTRIB "UNRELEASED"
+ENV SECTION ""
+
+# output directory
+ENV DIST_DIR=/tmp/nvidia-container-runtime-$PKG_VERS
+RUN mkdir -p $DIST_DIR
+
+# runc
+WORKDIR $GOPATH/src/github.com/opencontainers/runc
+
+ARG RUNC_COMMIT
+COPY runc/$RUNC_COMMIT/ /tmp/patches/runc
+RUN git clone https://github.com/docker/runc.git . && \
+    git fetch https://github.com/opencontainers/runc.git && \
+    git checkout $RUNC_COMMIT && \
+    git apply /tmp/patches/runc/* && \
+    if [ -f vendor.conf ]; then vndr; fi && \
+    make BUILDTAGS="seccomp apparmor selinux" && \
+    mv runc $DIST_DIR/nvidia-container-runtime
+
+# nvidia-container-runtime-hook
+COPY nvidia-container-runtime-hook/ $GOPATH/src/nvidia-container-runtime-hook
+
+RUN go get -v nvidia-container-runtime-hook && \
+    mv $GOPATH/bin/nvidia-container-runtime-hook $DIST_DIR/nvidia-container-runtime-hook
+
+COPY config.toml.xenial $DIST_DIR/config.toml
+
+WORKDIR $DIST_DIR
+COPY debian ./debian
+
+RUN dch --create --package nvidia-container-runtime -v "$REVISION" "v$REVISION" -D "$DISTRIB" && \
+    dch -r ""
+
+CMD debuild -eSECTION --dpkg-buildpackage-hook='sh debian/prepare' -i -us -uc -b && \
+    mv /tmp/*.deb /dist

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DIST_DIR  := $(CURDIR)/dist
 .NOTPARALLEL:
 .PHONY: all
 
-all: xenial centos7 stretch
+all: trusty xenial centos7 stretch
 
 trusty: 17.12.0-trusty 17.09.1-trusty 17.09.0-trusty 17.06.2-trusty 17.03.2-trusty 1.13.1-trusty 1.12.6-trusty
 

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,62 @@ DIST_DIR  := $(CURDIR)/dist
 
 all: xenial centos7 stretch
 
+trusty: 17.12.0-trusty 17.09.1-trusty 17.09.0-trusty 17.06.2-trusty 17.03.2-trusty 1.13.1-trusty 1.12.6-trusty
+
 xenial: 17.12.0-xenial 17.09.1-xenial 17.09.0-xenial 17.06.2-xenial 17.03.2-xenial 1.13.1-xenial 1.12.6-xenial
 
 centos7: 17.12.0-centos7 17.09.1-centos7 17.09.0-centos7 17.06.2-centos7 17.03.2-centos7 1.13.1-centos7 1.12.6-centos7
 
 stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2-stretch
+
+17.12.0-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="b2567b37d7b75eb4cf325b77297b140ea686ce8f" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.12.0" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
+
+17.09.1-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="3f2f8b84a77f73d38244dd690525642a72156c64" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.09.1" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
+
+17.09.0-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="3f2f8b84a77f73d38244dd690525642a72156c64" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.09.0" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
+
+17.06.2-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="810190ceaa507aa2727d7ae6f4790c76ec150bd2" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.06.2" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
+
+17.03.2-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="54296cf40ad8143b62dbcaa1d90e520a2136ddfe" \
+                        --build-arg PKG_VERS="$(VERSION)+docker17.03.2" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
+
+1.13.1-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="9df8b306d01f59d3a8029be411de015b7304dd8f" \
+                        --build-arg PKG_VERS="$(VERSION)+docker1.13.1" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
+
+1.12.6-trusty:
+	$(DOCKER) build --build-arg RUNC_COMMIT="50a19c6ff828c58e5dab13830bd3dacde268afe5" \
+                        --build-arg PKG_VERS="$(VERSION)+docker1.12.6" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t nvidia-container-runtime:$@ -f Dockerfile.trusty .
+	$(DOCKER) run --rm -v $(DIST_DIR)/trusty:/dist:Z nvidia-container-runtime:$@
 
 17.12.0-xenial:
 	$(DOCKER) build --build-arg RUNC_COMMIT="b2567b37d7b75eb4cf325b77297b140ea686ce8f" \

--- a/config.toml.trusty
+++ b/config.toml.trusty
@@ -1,0 +1,9 @@
+disable-require = false
+#swarm-resource = "DOCKER_RESOURCE_GPU"
+
+[nvidia-container-cli]
+#path = "/usr/bin/nvidia-container-cli"
+#debug = "/var/log/nvidia-container-runtime-hook.log"
+environment = []
+load-kmods = true
+ldconfig = "@/sbin/ldconfig.real"


### PR DESCRIPTION
This PR adds support for Ubuntu Trusty. It adds a `Dockerfile.trusty`, `config.toml.trusty`, as well as the required build steps in the `Makefile`.

The `Dockerfile.trusty` is almost identical to `Dockerfile.xenial`, with a few differences:
- `libseccomp2` has to be explicitly set to 2.2.3 (the version from Ubuntu backports), otherwise the build for Docker 17.12.0 fails, as by default it installs version 2.1.x.
- `build-essential` needs to be installed

I've successfully tested this on Trusty with Docker 1.12.6 and 17.9.0. There are corresponding PRs to NVIDIA/libnvidia-container#14 and NVIDIA/nvidia-docker#629.