### PR TITLE
multiarch support

### DIFF
--- a/Dockerfile.centos7
+++ b/Dockerfile.centos7
@@ -30,8 +30,17 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 
 ENV GOLANG_VERSION 1.9.4
-RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+RUN set -eux; \
+	\
+	arch="$(uname -m)"; \
+	case "${arch##*-}" in \
+		x86_64 | amd64) ARCH='amd64' ;; \
+		ppc64el | ppc64le) ARCH='ppc64le' ;; \
+		*) echo "unsupported architecture"; exit 1 ;; \
+	esac; \
+	wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -v -C /usr/local -xz
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 

--- a/Dockerfile.stretch
+++ b/Dockerfile.stretch
@@ -13,8 +13,17 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.9.4
-RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+RUN set -eux; \
+    \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+        x86_64 | amd64) ARCH='amd64' ;; \
+        ppc64el | ppc64le) ARCH='ppc64le' ;; \
+        *) echo "unsupported architecture" ; exit 1 ;; \
+    esac; \
+    wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -v -C /usr/local -xz
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 

--- a/Dockerfile.xenial
+++ b/Dockerfile.xenial
@@ -13,8 +13,17 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 ENV GOLANG_VERSION 1.9.4
-RUN wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+RUN set -eux; \
+    \
+    arch="$(uname -m)"; \
+    case "${arch##*-}" in \
+        x86_64 | amd64) ARCH='amd64' ;; \
+        ppc64el | ppc64le) ARCH='ppc64le' ;; \
+        *) echo "unsuported architecture" ; exit 1 ;; \
+    esac; \
+    wget -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz \
     | tar -v -C /usr/local -xz
+
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ DOCKER ?= docker
 VERSION := 1.1.1
 PKG_REV := 1
 
+PKG_ARCH = x86_64
+ifeq ("$(shell uname -m)", "ppc64le")
+PKG_ARCH=ppc64le
+endif
+
 DIST_DIR  := $(CURDIR)/dist
 
 .NOTPARALLEL:
@@ -68,7 +73,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/xenial:/dist:Z nvidia-container-runtime:$@
 
 17.12.0-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="b2567b37d7b75eb4cf325b77297b140ea686ce8f" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.12.0" \
@@ -76,7 +81,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.09.1-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="3f2f8b84a77f73d38244dd690525642a72156c64" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.09.1" \
@@ -84,7 +89,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.09.0-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="3f2f8b84a77f73d38244dd690525642a72156c64" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.09.0" \
@@ -92,7 +97,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.06.2-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="810190ceaa507aa2727d7ae6f4790c76ec150bd2" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.06.2" \
@@ -100,7 +105,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 17.03.2-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="54296cf40ad8143b62dbcaa1d90e520a2136ddfe" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker17.03.2" \
@@ -108,7 +113,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 1.13.1-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="9df8b306d01f59d3a8029be411de015b7304dd8f" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker1.13.1" \
@@ -116,7 +121,7 @@ stretch: 17.12.0-stretch 17.09.1-stretch 17.09.0-stretch 17.06.2-stretch 17.03.2
 	$(DOCKER) run --rm -v $(DIST_DIR)/centos7:/dist:Z nvidia-container-runtime:$@
 
 1.12.6-centos7:
-	$(DOCKER) build --build-arg PKG_ARCH="x86_64" \
+	$(DOCKER) build --build-arg PKG_ARCH="$(PKG_ARCH)" \
                         --build-arg RUNC_COMMIT="50a19c6ff828c58e5dab13830bd3dacde268afe5" \
                         --build-arg PKG_VERS="$(VERSION)" \
                         --build-arg PKG_REV="$(PKG_REV).docker1.12.6" \


### PR DESCRIPTION
This should work for architectures with nvidia cuda repos,
an architecture in the manifest list used as the FROM line, and downloadable go binaries.

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>