### PR TITLE
add ubuntu18.04 target (#22)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,11 @@
 
 .PHONY: all
 
-all: ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
+all: ubuntu18.04 ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
 
 # Build all packages for a specific distribution.
+ubuntu18.04: runtime-ubuntu18.04 hook-ubuntu18.04
+
 ubuntu16.04: runtime-ubuntu16.04 hook-ubuntu16.04
 
 ubuntu14.04: runtime-ubuntu14.04 hook-ubuntu14.04

--- a/runtime/Dockerfile.ubuntu
+++ b/runtime/Dockerfile.ubuntu
@@ -3,7 +3,7 @@ FROM nvidia/base/ubuntu:${VERSION_ID}
 
 # runc dependencies
 RUN apt-get update && \
-    apt-get install -t "$(lsb_release -cs)-backports" -y \
+    apt-get install -t "$(lsb_release -cs)" -y \
         libseccomp-dev && \
     apt-get install -y \
         pkg-config \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -10,7 +10,9 @@ DIST_DIR  := $(CURDIR)/../dist
 .NOTPARALLEL:
 .PHONY: all
 
-all: ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
+all: ubuntu18.04 ubuntu16.04 ubuntu14.04 debian9 debian8 centos7 amzn2 amzn1
+
+ubuntu18.04: $(addsuffix -ubuntu18.04, 18.03.0 17.03.2)
 
 ubuntu16.04: $(addsuffix -ubuntu16.04, 18.03.0 17.12.1 17.12.0 17.09.1 17.09.0 17.06.2 17.03.2 1.13.1 1.12.6)
 
@@ -50,6 +52,14 @@ amzn1: $(addsuffix -amzn1, 17.09.1 17.06.2 17.03.2)
 1.12.6-%-runc:
 	echo "50a19c6ff828c58e5dab13830bd3dacde268afe5"
 
+%-ubuntu18.04:
+	runc="$(shell $(MAKE) -s $@-runc)" && \
+	$(DOCKER) build --build-arg VERSION_ID="18.04" \
+                        --build-arg RUNC_COMMIT="$${runc}" \
+                        --build-arg PKG_VERS="$(VERSION)+docker$*" \
+                        --build-arg PKG_REV="$(PKG_REV)" \
+                        -t "nvidia/runtime/ubuntu:18.04-docker$*" -f Dockerfile.ubuntu .
+	$(DOCKER) run --rm -v $(DIST_DIR)/ubuntu18.04:/dist:Z "nvidia/runtime/ubuntu:18.04-docker$*"
 
 %-ubuntu16.04:
 	runc="$(shell $(MAKE) -s $@-runc)" && \


### PR DESCRIPTION
I'm not happy with the change to the `backports` line, but somehow using that apt tag doesn't seem to work. It gives:
```
E: The value 'bionic-packports' is invalid for APT::Default-Release as such a release is not available in the sources
```
While the backports repository seems to be enabled by default in /etc/apt/sources.list` file in the Ubuntu 18.04 Docker image:
```
deb http://archive.ubuntu.com/ubuntu/ bionic-backports main restricted universe multiverse
```
This doesn't build though, it fails at the same step as described in https://github.com/NVIDIA/nvidia-container-runtime/issues/21