### PR TITLE
Add `--no-cgroups` to config

### DIFF
--- a/hook/nvidia-container-runtime-hook/hook_config.go
+++ b/hook/nvidia-container-runtime-hook/hook_config.go
@@ -19,6 +19,7 @@ type CLIConfig struct {
 	Debug       *string  `toml:"debug"`
 	Ldcache     *string  `toml:"ldcache"`
 	LoadKmods   bool     `toml:"load-kmods"`
+	NoCgroups   bool     `toml:"no-cgroups"`
 	User        *string  `toml:"user"`
 	Ldconfig    *string  `toml:"ldconfig"`
 }
@@ -41,6 +42,7 @@ func getDefaultHookConfig() (config HookConfig) {
 			Debug:       nil,
 			Ldcache:     nil,
 			LoadKmods:   true,
+			NoCgroups:   false,
 			User:        nil,
 			Ldconfig:    nil,
 		},

--- a/hook/nvidia-container-runtime-hook/main.go
+++ b/hook/nvidia-container-runtime-hook/main.go
@@ -116,7 +116,9 @@ func doPrestart() {
 	if cli.Ldconfig != nil {
 		args = append(args, fmt.Sprintf("--ldconfig=%s", *cli.Ldconfig))
 	}
-
+        if cli.NoCgroups {
+		args = append(args, "--no-cgroups")
+	}
 	if len(nvidia.Devices) > 0 {
 		args = append(args, fmt.Sprintf("--device=%s", nvidia.Devices))
 	}


### PR DESCRIPTION
To run `nvidia-container-cli` inside of unprivileged LXC. 