### PR TITLE
Fix bug causing GPU unavaliable after updating container resource

### DIFF
--- a/runtime/runc/3f2f8b84a77f73d38244dd690525642a72156c64/0001-Add-prestart-hook-nvidia-container-runtime-hook-to-t.patch
+++ b/runtime/runc/3f2f8b84a77f73d38244dd690525642a72156c64/0001-Add-prestart-hook-nvidia-container-runtime-hook-to-t.patch
@@ -1,7 +1,8 @@
-From 3f520de8ae5b5107811261734c15ee99b35ecb74 Mon Sep 17 00:00:00 2001
+From 851d1f7e806a8782f129e7e5e8253bffd8752593 Mon Sep 17 00:00:00 2001
 From: Felix Abecassis <fabecassis@nvidia.com>
 Date: Wed, 3 Jan 2018 11:50:02 -0800
-Subject: [PATCH] Add prestart hook nvidia-container-runtime-hook to the config
+Subject: [PATCH 1/2] Add prestart hook nvidia-container-runtime-hook to the
+ config
 
 Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>
 ---

--- a/runtime/runc/3f2f8b84a77f73d38244dd690525642a72156c64/0002-Fix-bug-causing-GPU-unavaliable-after-updating-conta.patch
+++ b/runtime/runc/3f2f8b84a77f73d38244dd690525642a72156c64/0002-Fix-bug-causing-GPU-unavaliable-after-updating-conta.patch
@@ -1,0 +1,43 @@
+From 6c699197de157e08e26a6c7ef4329f050fdbe1bd Mon Sep 17 00:00:00 2001
+From: tkanng <tkanng@gmail.com>
+Date: Wed, 1 May 2019 11:47:33 +0800
+Subject: [PATCH 2/2] Fix bug causing GPU unavaliable after updating container
+ resources
+
+---
+ libcontainer/cgroups/fs/devices.go | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/libcontainer/cgroups/fs/devices.go b/libcontainer/cgroups/fs/devices.go
+index 0ac5b4e..30d85de 100644
+--- a/libcontainer/cgroups/fs/devices.go
++++ b/libcontainer/cgroups/fs/devices.go
+@@ -3,6 +3,8 @@
+ package fs
+ 
+ import (
++	"strings"
++
+ 	"github.com/opencontainers/runc/libcontainer/cgroups"
+ 	"github.com/opencontainers/runc/libcontainer/configs"
+ 	"github.com/opencontainers/runc/libcontainer/system"
+@@ -29,6 +31,16 @@ func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
+ 	if system.RunningInUserNS() {
+ 		return nil
+ 	}
++	devList, err := readFile(path, "devices.list")
++	if err != nil {
++		return err
++	}
++	// "a *:* rwm" is devices.list's initial value
++	// if devList starts with "a *:* rwm", it means that it's the first time to set devices cgroup
++	// if it doesn't, it means that devices cgroup has been updated, so just return.
++	if !strings.HasPrefix(devList, "a *:* rwm") {
++		return nil
++	}
+ 
+ 	devices := cgroup.Resources.Devices
+ 	if len(devices) > 0 {
+-- 
+2.7.4
+


### PR DESCRIPTION
Hi, this may be a solution for https://github.com/NVIDIA/nvidia-docker/issues/966 and https://github.com/NVIDIA/nvidia-docker/issues/515 .

## 1. Root cause
Each time the `docker update` command is executed, `runc` **updates all cgroup subsystems** according to the parameter , such as: cpu-quota, cpu-set,mem  and the contents of `state.json` (which contains the state of the current container). Below is all cgroup subsystems：
```go
subsystems = subsystemSet{
    &CpusetGroup{},
    &DevicesGroup{},
    &MemoryGroup{},
    &CpuGroup{},
    &CpuacctGroup{},
    &PidsGroup{},
    &BlkioGroup{},
    &HugetlbGroup{},
    &NetClsGroup{},
    &NetPrioGroup{},
    &PerfEventGroup{},
    &FreezerGroup{},
    &NameGroup{GroupName: "name=systemd", Join: true},
}
```
Unfortunately, `nvidia-docker` injects GPU devices by directly calling `libnvidia-container` **without synchronizing the device information into `state.json`,** such as: `/dev/nvidiactl , /dev/nvidia0, /dev/nvidia1..etc.`. Therefore, there is no GPU-related information in `state.json`, which essentially "undoing" what libnvidia-container had set up in regards to these devices when `docker update` is executed.

## 2. Solutions
  This pull request is the implementation for solution2 to ensure container's devices Cgroup can be set **only once** . 

- **Updates docker's internal state with GPU devices information**: 
    Set the container's device parameter in advance before actually calling `libnvidia-container`. For example: if you have a GPU container(`NVIDIA_VISIBLE_DEVICES=0`), you can set the `device` parameter like:
    ```
    # it works 'fine'
    --device=/dev/nvidiactl:/dev/nvidiactl:rw  --device=/dev/nvidia0:/dev/nvidia0:rw
    ```
    Experiment：
    - NOT setting `device` parameter:
        ```
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker run --runtime=nvidia --name no-dev -it -d  -e NVIDIA_VISIBLE_DEVICES=0 ubuntu:16.04 bash
        3cc1795a2e0784277352bb92c457db12a4328b51d6fe09861f83030bab6be5b2
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker run no-dev nvidia-smi
        Unable to find image 'no-dev:latest' locally
        ^C
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker exec -it no-dev nvidia-smi
        Wed May  1 05:23:18 2019       
        +-----------------------------------------------------------------------------+
        | NVIDIA-SMI 410.78       Driver Version: 410.78       CUDA Version: N/A      |
        |-------------------------------+----------------------+----------------------+
        | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
        | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
        |===============================+======================+======================|
        |   0  GeForce GTX 108...  Off  | 00000000:00:07.0 Off |                  N/A |
        | 12%   22C    P5    27W / 250W |      0MiB / 11178MiB |      0%      Default |
        +-------------------------------+----------------------+----------------------+
                                                                                    
        +-----------------------------------------------------------------------------+
        | Processes:                                                       GPU Memory |
        |  GPU       PID   Type   Process name                             Usage      |
        |=============================================================================|
        |  No running processes found                                                 |
        +-----------------------------------------------------------------------------+
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker update no-dev --cpu-quota 100000
        no-dev
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker exec -it no-dev nvidia-smi
        Failed to initialize NVML: Unknown Error
        ```
    - Setting `device` parameter:
        ```shell
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker run --runtime=nvidia --name has-dev --device=/dev/nvidiactl:/dev/nvidiactl:rw  --device=/dev/nvidia0:/dev/nvidia0:rw  -it -d  -e NVIDIA_VISIBLE_DEVICES=0 ubuntu:16.04 bash
        1fbfa56804ca92da73076e7a0ec2ea076d082ae4e89ddbc3a43a8231e7684ba6
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker exec -it has-dev nvidia-smi
        Wed May  1 05:27:36 2019       
        +-----------------------------------------------------------------------------+
        | NVIDIA-SMI 410.78       Driver Version: 410.78       CUDA Version: N/A      |
        |-------------------------------+----------------------+----------------------+
        | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
        | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
        |===============================+======================+======================|
        |   0  GeForce GTX 108...  Off  | 00000000:00:07.0 Off |                  N/A |
        | 12%   21C    P5    28W / 250W |      0MiB / 11178MiB |      0%      Default |
        +-------------------------------+----------------------+----------------------+
                                                                                    
        +-----------------------------------------------------------------------------+
        | Processes:                                                       GPU Memory |
        |  GPU       PID   Type   Process name                             Usage      |
        |=============================================================================|
        |  No running processes found                                                 |
        +-----------------------------------------------------------------------------+
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker update has-dev --cpu-quota 100000
        has-dev
        root@iZhp37kmiszbkwzt5oh9csZ:~# docker exec -it has-dev nvidia-smi
        Wed May  1 05:27:48 2019       
        +-----------------------------------------------------------------------------+
        | NVIDIA-SMI 410.78       Driver Version: 410.78       CUDA Version: N/A      |
        |-------------------------------+----------------------+----------------------+
        | GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
        | Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
        |===============================+======================+======================|
        |   0  GeForce GTX 108...  Off  | 00000000:00:07.0 Off |                  N/A |
        | 12%   22C    P5    27W / 250W |      0MiB / 11178MiB |      0%      Default |
        +-------------------------------+----------------------+----------------------+
                                                                                    
        +-----------------------------------------------------------------------------+
        | Processes:                                                       GPU Memory |
        |  GPU       PID   Type   Process name                             Usage      |
        |=============================================================================|
        |  No running processes found                                                 |
        +-----------------------------------------------------------------------------+
        root@iZhp37kmiszbkwzt5oh9csZ:~# 

        ```
    - Implementation：https://github.com/tkanng/runc/commit/e7821fdec0d8055306e1dc14d285c47d99f0c719
    - Drawbacks:
        - Need to import nvml library.
        - Unfortunately, current implementation of DevicesGroup in runc may cause devices **to be temporarily unavailable**. Below is the code for the devices subsystem update resource. Devices[0].Allow is **false** and it's Type is `a`, MajorNum is -1, MniorNum is -1, which means container has no permission to access **any device**.
        ```go
        //  runc/libcontainer/cgroup/fs/devices.go
        devices := cgroup.Resources.Devices
        // devices's firsr element is
        // devices[0]: Type:a, Major:-1, Minor: -1, Allow:false
        if len(devices) > 0 {
            for _, dev := range devices {
                file := "devices.deny"
                if dev.Allow {
                    file = "devices.allow"
                }
                // it will write 'a *:*' to devices.deny while entering the loop for the first time, which makes the container has no permission to access any device .
                if err := writeFile(path, file, dev.CgroupString()); err != nil {
                    return err
                }
            }
            return nil
        }
        ```
       ![flow](https://raw.githubusercontent.com/tkanng/static-resource/master/devices.png)
- Ensure container's devices Cgroup can be set **only once**:
    - Docker API doesn't allow to update devices configuration to keep containers 'immutable'. So that there is **no need to update devices CGroup when the container is running**.
    ```go
    // docker udpatable resource type
    type UpdateResource struct {
        BlkioWeight                  uint64            `protobuf:"varint,1,opt,name=blkioWeight" json:"blkioWeight,omitempty"`
        CpuShares                    uint64            `protobuf:"varint,2,opt,name=cpuShares" json:"cpuShares,omitempty"`
        CpuPeriod                    uint64            `protobuf:"varint,3,opt,name=cpuPeriod" json:"cpuPeriod,omitempty"`
        CpuQuota                     uint64            `protobuf:"varint,4,opt,name=cpuQuota" json:"cpuQuota,omitempty"`
        CpusetCpus                   string            `protobuf:"bytes,5,opt,name=cpusetCpus" json:"cpusetCpus,omitempty"`
        CpusetMems                   string            `protobuf:"bytes,6,opt,name=cpusetMems" json:"cpusetMems,omitempty"`
        MemoryLimit                  uint64            `protobuf:"varint,7,opt,name=memoryLimit" json:"memoryLimit,omitempty"`
        MemorySwap                   uint64            `protobuf:"varint,8,opt,name=memorySwap" json:"memorySwap,omitempty"`
        MemoryReservation            uint64            `protobuf:"varint,9,opt,name=memoryReservation" json:"memoryReservation,omitempty"`
        KernelMemoryLimit            uint64            `protobuf:"varint,10,opt,name=kernelMemoryLimit" json:"kernelMemoryLimit,omitempty"`
        KernelTCPMemoryLimit         uint64            `protobuf:"varint,11,opt,name=kernelTCPMemoryLimit" json:"kernelTCPMemoryLimit,omitempty"`
        BlkioLeafWeight              uint64            `protobuf:"varint,12,opt,name=blkioLeafWeight" json:"blkioLeafWeight,omitempty"`
        BlkioWeightDevice            []*WeightDevice   `protobuf:"bytes,13,rep,name=blkioWeightDevice" json:"blkioWeightDevice,omitempty"`
        BlkioThrottleReadBpsDevice   []*ThrottleDevice `protobuf:"bytes,14,rep,name=blkioThrottleReadBpsDevice" json:"blkioThrottleReadBpsDevice,omitempty"`
        BlkioThrottleWriteBpsDevice  []*ThrottleDevice `protobuf:"bytes,15,rep,name=blkioThrottleWriteBpsDevice" json:"blkioThrottleWriteBpsDevice,omitempty"`
        BlkioThrottleReadIopsDevice  []*ThrottleDevice `protobuf:"bytes,16,rep,name=blkioThrottleReadIopsDevice" json:"blkioThrottleReadIopsDevice,omitempty"`
        BlkioThrottleWriteIopsDevice []*ThrottleDevice `protobuf:"bytes,17,rep,name=blkioThrottleWriteIopsDevice" json:"blkioThrottleWriteIopsDevice,omitempty"`
    }
    ```
    - `devices.list` contains all devices that the container has permission to access. Its initial value is 'a *:* rwm' which means the process has permission to access all devices.
    -  runc can set DeviceCGroup  properly by adding entries to `devices.allow` and `devices.deny`. Below is default allowed-devices:
    ```
    c 1:5 rwm
    c 1:3 rwm
    c 1:9 rwm
    c 1:8 rwm
    c 5:0 rwm
    c 5:1 rwm
    c *:* m
    b *:* m
    c 1:7 rwm
    c 136:* rwm
    c 5:2 rwm
    c 10:200 rwm
    ```
    - By determining whether `devices.list`'s content is `a *:* rwm`,we can ensure device Cgroup can be set **ONLY ONCE**.
    - Here is the patch to runc: https://github.com/tkanng/runc/commit/3ee31750ad09f7e25feb7af068270f229db503d7