### PR TITLE
Ubuntu 20.04 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -49,6 +49,10 @@ amd64:ubuntu16.04:
 amd64:ubuntu18.04:
   <<: *build_definition
 
+amd64:ubuntu20.04:
+  <<: *build_definition
+
+
 unit-tests:
   stage: test
   image: ${CI_REGISTRY_IMAGE}/runtime/ubuntu18.04

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ REGISTRY := nvidia
 .NOTPARALLEL:
 .PHONY: all
 
-all: ubuntu18.04 ubuntu16.04 debian10 debian9 centos7 amzn2 amzn1 opensuse-leap15.1
+all: ubuntu20.04 ubuntu18.04 ubuntu16.04 debian10 debian9 centos7 amzn2 amzn1 opensuse-leap15.1
 
 push%:
 	$(DOCKER) push "$(REGISTRY)/runtime/$*"


### PR DESCRIPTION
Hi, Ubuntu 20.04 LTS release is scheduled at [April 23rd](https://wiki.ubuntu.com/FocalFossa/ReleaseSchedule), and [daily build](http://cdimage.ubuntu.com/daily-live/pending/) is already available.

I'm not sure the release cycle of nvidia-container-runtime, but it would be happy if we can get a beta release for ubuntu 20.04 or something like this... :thinking: 

It seems the similar change is necessary to:
- https://github.com/NVIDIA/nvidia-docker.git
- https://github.com/NVIDIA/libnvidia-container.git
- https://github.com/NVIDIA/container-toolkit.git
