### PR TITLE
Remove duplicate line of exec start in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ You might need to merge the new argument with your existing configuration.
 sudo mkdir -p /etc/systemd/system/docker.service.d
 sudo tee /etc/systemd/system/docker.service.d/override.conf <<EOF
 [Service]
-ExecStart=
 ExecStart=/usr/bin/dockerd --host=fd:// --add-runtime=nvidia=/usr/bin/nvidia-container-runtime
 EOF
 sudo systemctl daemon-reload


### PR DESCRIPTION
For registering nvidia runtime to docker engine
command contains a duplicate line for exec start that should be removed.